### PR TITLE
Deserialization fix

### DIFF
--- a/src/KafkaClient/Protocol/KafkaEncoder.cs
+++ b/src/KafkaClient/Protocol/KafkaEncoder.cs
@@ -145,7 +145,7 @@ namespace KafkaClient.Protocol
                         var offset = reader.ReadInt64();
                         DateTimeOffset? timestamp = null;
 
-                        if (context.ApiVersion >= 2) {
+                        if (context.ApiVersion >= 3) {
                             var milliseconds = reader.ReadInt64();
                             if (milliseconds >= 0) {
                                 timestamp = DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);

--- a/src/KafkaClient/Protocol/KafkaEncoder.cs
+++ b/src/KafkaClient/Protocol/KafkaEncoder.cs
@@ -230,7 +230,7 @@ namespace KafkaClient.Protocol
                     var host = reader.ReadString();
                     var port = reader.ReadInt32();
                     string rack = null;
-                    if (context.ApiVersion >= 1) {
+                    if (context.ApiVersion >= 2) {
                         rack = reader.ReadString();
                     }
 
@@ -243,7 +243,7 @@ namespace KafkaClient.Protocol
                 }
 
                 int? controllerId = null;
-                if (context.ApiVersion >= 1) {
+                if (context.ApiVersion >= 2) {
                     controllerId = reader.ReadInt32();
                 }
 
@@ -252,7 +252,7 @@ namespace KafkaClient.Protocol
                     var topicError = (ErrorCode) reader.ReadInt16();
                     var topicName = reader.ReadString();
                     bool? isInternal = null;
-                    if (context.ApiVersion >= 1) {
+                    if (context.ApiVersion >= 2) {
                         isInternal = reader.ReadBoolean();
                     }
 


### PR DESCRIPTION
Deserialization of MetadataResponse and ProduceResponse were constantly failing for me, with "System.IO.EndOfStreamException: Attempted to read past the end of the stream.", so I was suspicious of trying to read more data then needed.

This fix is completely experimental, I haven't checked the kafka protocol reference whether this is correct, or not. It just works for me.